### PR TITLE
Add DuckDB module

### DIFF
--- a/src/python/modicum/Modules.py
+++ b/src/python/modicum/Modules.py
@@ -9,6 +9,7 @@ from modules.stable_diffusion import _stable_diffusion
 from modules.fastchat import _fastchat
 from modules.sdxl import _sdxl
 from modules.lora import _lora_training, _lora_inference
+from modules.duckdb import _duckdb
 
 def get_bacalhau_jobspec(template_name, params):
     """
@@ -29,4 +30,5 @@ modules = {
     "fastchat:v0.0.1": _fastchat,
     "filecoin_data_prep:v0.0.1": _filecoin_data_prep,
     "deterministic_wasm:v0.0.1": _deterministic_wasm,
+    "duckdb:v0.0.1": _duckdb,
 }

--- a/src/python/modules/duckdb.py
+++ b/src/python/modules/duckdb.py
@@ -1,0 +1,65 @@
+import yaml
+
+def _duckdb(params: str):
+    if params.startswith("{"):
+        params = yaml.safe_load(params)
+    else:
+        raise Exception("Please set params to yaml like {'query': 'SELECT...', 'inputs_cid': 'Qm...'}")
+
+    return {
+        "APIVersion": "V1beta1",
+        "Metadata": {
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "Requester": {}
+        },
+        "Spec": {
+            "Engine": "Docker",
+            "Verifier": "Noop",
+            "Publisher": "Estuary",
+            "PublisherSpec": {
+                "Type": "Estuary"
+            },
+            "Docker": {
+                "Image": "31z4/bacalhau-duckdb:0.0.1",
+                "Entrypoint": [
+                    "./duckdb",
+                    "-init",
+                    "/init.sql",
+                    "-echo",
+                    "-s",
+                    params["query"]
+                ],
+            },
+            "Language": {
+                "JobContext": {}
+            },
+            "Wasm": {
+                "EntryModule": {}
+            },
+            "Resources": {
+                "GPU": ""
+            },
+            "Network": {
+                "Type": "None"
+            },
+            "Timeout": 1800,
+            "inputs": [
+                {
+                    "StorageSource": "IPFS",
+                    "Name": "inputs",
+                    "CID": params["inputs_cid"],
+                    "path": "/inputs",
+                }
+            ],
+            "outputs": [
+                {
+                    "StorageSource": "IPFS",
+                    "Name": "outputs",
+                    "path": "/outputs"
+                }
+            ],
+            "Deal": {
+                "Concurrency": 1
+            },
+        },
+    }


### PR DESCRIPTION
Hi all 👋 I'm attending [Open Data Hack](https://www.encode.club/open-data-hack) and building a project that gathers public data about [Filecoin Saturn](https://saturn.tech) network and analyses these data to gain useful insights. I'd love to use Lilypad for the analysis ☺️ 

So in this PR I introduce the initial version of [DuckDB](https://duckdb.org) 🦆  module that allows to run arbitrary SQL queries against IPFS/Filecoin data.

As discussed earlier on #bacalhau-lilypad Slack channel I publish this PR without throughout testing hoping for help from maintainers.

<img width="385" alt="image" src="https://github.com/bacalhau-project/lilypad-modicum/assets/3657959/0e3a93d6-f880-4f14-a202-0dfbd5edb3f0">

Although, the [Docker image](https://github.com/31z4/saturn-observatory/blob/5a3126de53b3aa1e3b81e37ab7f16c7422537b5b/bacalhau/Dockerfile) itself and the job spec was successfully tested with Bacalhau by running real SQL query against real data sitting on IPFS.