### PR TITLE
Add bash version requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ We need the following installed:
 
  * docker
  * jq
+ * bash version 4.0.0 or higher (your default bash is likely outdated)
 
 #### compile contract
 


### PR DESCRIPTION
Add a requirement to install an updated version of bash to `CONTRIBUTING.md` since many syntaxes break under bash with a lower version (mostly system-default).
Probably should note this on the main `README.md` as well since `lilypad` CLI might also break.