### PR TITLE
fixes: modules/decenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ supervisord.pid
 .env
 ops/testnet/.terraform/providers
 .idea/
+.DS_Store

--- a/src/js/scripts/ensure-module-costs.js
+++ b/src/js/scripts/ensure-module-costs.js
@@ -22,7 +22,7 @@ const MODULE_COSTS = {
   "fastchat:v0.0.1": 2,
   "filecoin_data_prep:v0.0.1": 100,
   "deterministic_wasm:v0.0.1": 2,
-  "decenter:main": 1,
+  "decenter:main": 200,
 }
 
 async function main() {

--- a/src/python/modules/decenter.py
+++ b/src/python/modules/decenter.py
@@ -17,6 +17,7 @@ class App:
     t: str = "linear-regression.ipynb"
     i: str = "/app/samples/sample_v3/sample_v3.zip"
     seed: int = 0  # not used but for deterministic
+    image_tag: str = "v1.5.0"
 
     @property
     def json(self) -> str:
@@ -65,7 +66,7 @@ def _decenter(params: str):
                     f"/app/venv/bin/python main.py {app.train_cmd}",
                     f"-t={app.t} -i={app.i}",
                 ],
-                "Image": "ghcr.io/decenter-ai/compute.decenter-ai/decenter.compute.v1:main",
+                "Image": f"ghcr.io/decenter-ai/compute:{app.image_tag}",
                 "EnvironmentVariables": [
                     # f"PROMPT={params.get('prompt', 'question mark floating in space')}",
                     # f"RANDOM_SEED={params.get('seed', 0)}",

--- a/src/python/modules/decenter.py
+++ b/src/python/modules/decenter.py
@@ -24,7 +24,7 @@ class App:
     t: str = "linear-regression.ipynb"
     i: str = "/app/samples/sample_v3/sample_v3.zip"
     seed: int = 0  # not used but for deterministic
-    image_tag: str = "main"
+    image_tag: str = "v1.5.5" #stable version checkout stable releases over https://github.com/DeCenter-AI/compute.decenter-ai/releases
     
     gpu: int =1 #1-8
     cpu: int|str = CPU_CONFIG[8]

--- a/src/python/modules/decenter.py
+++ b/src/python/modules/decenter.py
@@ -24,7 +24,7 @@ class App:
     t: str = "linear-regression.ipynb"
     i: str = "/app/samples/sample_v3/sample_v3.zip"
     seed: int = 0  # not used but for deterministic
-    image_tag: str = "v1.5.0"
+    image_tag: str = "main"
     
     gpu: int =1 #1-8
     cpu: int|str = CPU_CONFIG[8]

--- a/src/python/modules/decenter.py
+++ b/src/python/modules/decenter.py
@@ -76,8 +76,9 @@ def _decenter(params: str):
                     "/app/venv/bin/python",
                     "main.py",
                     app.train_cmd,
-                    f"-t={app.t} -i={app.i}",
-                    "2>/dev/null ",
+                    f"-t={app.t}",
+                    f"-i={app.i}",
+                    "2>/dev/null",
                     # "> /dev/null 2>&1"
                 ],
                 "Image": f"ghcr.io/decenter-ai/compute:{app.image_tag}",


### PR DESCRIPTION
Equivalent Bacalhau spec:

```
bacalhau docker run --download \
  --id-only \
  --timeout 3600 \
  --wait-timeout-secs 3600 \
  --wait \
  --gpu 1 \
  --cpu 8 \
  -i src=https://gateway.lighthouse.storage/ipfs/QmRwvooN7Yfa6Gx8aVcf5cV7MAAMHmo5Q5JTt5234jf3qo,dst=/inputs \
  ghcr.io/decenter-ai/compute:v1.5.5 -- \
  headbrain.ipynb /inputs/QmRwvooN7Yfa6Gx8aVcf5cV7MAAMHmo5Q5JTt5234jf3qo
```

```
bacalhau docker run --download \
  --id-only \
  --timeout 3600 \
  --wait-timeout-secs 3600 \
  --wait \
  --gpu 1 \
  --cpu 8 \
  ghcr.io/decenter-ai/compute:v1.5.5 -- \
  linear-regression.ipynb /app/samples/sample_v3/sample_v3.zip
```