### PR TITLE
Integration of Score Creator Module for DeFi in v1

### DIFF
--- a/src/python/modicum/Modules.py
+++ b/src/python/modicum/Modules.py
@@ -11,6 +11,7 @@ from modules.sdxl import _sdxl
 from modules.lora import _lora_training, _lora_inference
 from modules.duckdb import _duckdb
 from modules.decenter import _decenter
+from modules.scorepoc import _scorepoc
 
 def get_bacalhau_jobspec(template_name, params):
     """
@@ -33,4 +34,5 @@ modules = {
     "deterministic_wasm:v0.0.1": _deterministic_wasm,
     "duckdb:v0.0.1": _duckdb,
     "decenter:main": _decenter,
+    "scorepoc:v0.0.1": _scorepoc,
 }

--- a/src/python/modules/scorepoc.py
+++ b/src/python/modules/scorepoc.py
@@ -1,0 +1,50 @@
+def _scorepoc():
+    return {
+        "APIVersion": "V1beta1",
+        "Metadata": {
+            "CreatedAt": "0001-01-01T00:00:00Z",
+            "Requester": {}
+        },
+        "Spec": {
+            "Deal": {
+                "Concurrency": 1
+            },
+            "Docker": {
+                "Image": "solityresearch/poc-testv5@sha256:82ebb534e0495d4c82053c7b974083c3c6e20060d7309995982e77229ecc60c0"
+            },
+            "Engine": "Docker",
+            "Network": {
+                "Type": "None"
+            },
+            "Publisher": "Estuary",
+            "PublisherSpec": {
+                "Type": "Estuary"
+            },
+            "Resources": {
+                "GPU": ""
+            },
+            "Timeout": 1800,
+            "Verifier": "Noop",
+            "Language": {
+                "JobContext": {}
+            },
+            "Wasm": {
+                "EntryModule": {}
+            },
+            "inputs": [
+                {
+                    "StorageSource": "URLDownload",
+                    "Name": "https://pods.dev-solity.net/test-decentralized/social-data",
+                    "URL": "https://pods.dev-solity.net/test-decentralized/social-data",
+                    "path": "/inputs"
+                }
+            ],
+            "outputs": [
+                {
+                    "StorageSource": "IPFS",
+                    "Name": "outputs",
+                    "path": "/outputs"
+                }
+            ]
+        }
+    }


### PR DESCRIPTION
I've developed a proof-of-concept for a score creator contract related to DeFi. While I was able to successfully deploy and test it on the FVM calibration network for v0, I couldn't evaluate it on the Sepolia network for v0 as it's deprecated and no longer supported, as per your information.

To continue testing and make necessary improvements, I've replicated the functionality for v1 and integrated it into the module. Kindly review the changes and provide feedback.